### PR TITLE
Warning during make in yml2md.py

### DIFF
--- a/build/yml2md.py
+++ b/build/yml2md.py
@@ -17,7 +17,7 @@ def write_file(filename, data):
 def load_yaml(input):
     f = read_file(input)
     try:
-        return yaml.load(f)
+        return yaml.load(f, Loader=yaml.FullLoader)
     except yaml.YAMLError:
         return []
 


### PR DESCRIPTION
Fix to resolve warning due to unsafe yaml Loader: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation